### PR TITLE
Allow passing of mixed_instances_policy to make use of spot pools

### DIFF
--- a/examples/complete-using-mixed-instance-policy/main.tf
+++ b/examples/complete-using-mixed-instance-policy/main.tf
@@ -1,0 +1,87 @@
+terraform {
+  required_version = ">= 0.11.4"
+}
+
+
+provider "aws" {
+  region = "${var.region}"
+  version = "2.12.0"
+  
+}
+
+provider "null" {
+  version = "~> 2.1"
+}
+
+
+locals {
+  userdata = <<USERDATA
+    #!/bin/bash
+    cat <<"__EOF__" > /home/ec2-user/.ssh/config
+    Host *
+        StrictHostKeyChecking no
+    __EOF__
+    chmod 600 /home/ec2-user/.ssh/config
+    chown ec2-user:ec2-user /home/ec2-user/.ssh/config
+  USERDATA
+}
+
+data "aws_availability_zones" "available" {}
+
+
+module "vpc" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=0.11/master"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  cidr_block = "10.0.0.0/16"
+}
+
+module "subnets" {
+  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=0.11/master"
+  availability_zones  = ["${data.aws_availability_zones.available.names}"]
+  namespace           = "${var.namespace}"
+  stage               = "${var.stage}"
+  name                = "${var.name}"
+  providers           = {
+    aws = "aws"
+  }
+  vpc_id              = "${module.vpc.vpc_id}"
+  igw_id              = "${module.vpc.igw_id}"
+  cidr_block          = "${module.vpc.vpc_cidr_block}"
+  nat_gateway_enabled = "true"
+}
+
+module "autoscale_group" {
+  source = "../../"
+
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+  name      = "${var.name}"
+
+  image_id                    = "${var.image_id}"
+  instance_type               = "${var.instance_type}"
+  security_group_ids          = []
+  subnet_ids                  = ["${module.subnets.public_subnet_ids}"]
+  health_check_type           = "${var.health_check_type}"
+  min_size                    = "${var.min_size}"
+  max_size                    = "${var.max_size}"
+  wait_for_capacity_timeout   = "${var.wait_for_capacity_timeout}"
+  associate_public_ip_address = true
+  user_data_base64            = "${base64encode(local.userdata)}"
+
+  tags = {
+    Tier              = "1"
+    KubernetesCluster = "us-west-2.testing.cloudposse.co"
+  }
+
+  # Auto-scaling policies and CloudWatch metric alarms
+  autoscaling_policies_enabled           = "true"
+  cpu_utilization_high_threshold_percent = "${var.cpu_utilization_high_threshold_percent}"
+  cpu_utilization_low_threshold_percent  = "${var.cpu_utilization_low_threshold_percent}"
+
+  ##
+  mixed_type = "${var.mixed_type}"
+  autoscaling_configs = "${var.autoscaling_configs}"
+  autoscaling_instances = "${var.autoscaling_instances}"
+}

--- a/examples/complete-using-mixed-instance-policy/outputs.tf
+++ b/examples/complete-using-mixed-instance-policy/outputs.tf
@@ -1,0 +1,54 @@
+output "launch_template_id" {
+  description = "The ID of the launch template"
+  value       = "${module.autoscale_group.launch_template_id}"
+}
+
+output "launch_template_arn" {
+  description = "The ARN of the launch template"
+  value       = "${module.autoscale_group.launch_template_arn}"
+}
+
+output "autoscaling_group_id" {
+  description = "The autoscaling group id"
+  value       = "${module.autoscale_group.autoscaling_group_id}"
+}
+
+output "autoscaling_group_name" {
+  description = "The autoscaling group name"
+  value       = "${module.autoscale_group.autoscaling_group_name}"
+}
+
+output "autoscaling_group_arn" {
+  description = "The ARN for this AutoScaling Group"
+  value       = "${module.autoscale_group.autoscaling_group_arn}"
+}
+
+output "autoscaling_group_min_size" {
+  description = "The minimum size of the autoscale group"
+  value       = "${module.autoscale_group.autoscaling_group_min_size}"
+}
+
+output "autoscaling_group_max_size" {
+  description = "The maximum size of the autoscale group"
+  value       = "${module.autoscale_group.autoscaling_group_max_size}"
+}
+
+output "autoscaling_group_desired_capacity" {
+  description = "The number of Amazon EC2 instances that should be running in the group"
+  value       = "${module.autoscale_group.autoscaling_group_desired_capacity}"
+}
+
+output "autoscaling_group_default_cooldown" {
+  description = "Time between a scaling activity and the succeeding scaling activity"
+  value       = "${module.autoscale_group.autoscaling_group_default_cooldown}"
+}
+
+output "autoscaling_group_health_check_grace_period" {
+  description = "Time after instance comes into service before checking health"
+  value       = "${module.autoscale_group.autoscaling_group_health_check_grace_period}"
+}
+
+output "autoscaling_group_health_check_type" {
+  description = "`EC2` or `ELB`. Controls how health checking is done"
+  value       = "${module.autoscale_group.autoscaling_group_health_check_type}"
+}

--- a/examples/complete-using-mixed-instance-policy/variables.tf
+++ b/examples/complete-using-mixed-instance-policy/variables.tf
@@ -1,0 +1,117 @@
+variable "namespace" {
+  type        = "string"
+  default     = "eg"
+  description = "Namespace, which could be your organization name, e.g. 'eg' or 'cp'"
+}
+
+variable "stage" {
+  type        = "string"
+  default     = "testing"
+  description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
+}
+
+variable "environment" {
+  type        = "string"
+  default     = ""
+  description = "Environment, e.g. 'testing', 'UAT'"
+}
+
+variable "name" {
+  type        = "string"
+  default     = "test"
+  description = "Solution name, e.g. 'app' or 'cluster'"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+}
+
+variable "region" {
+  type        = "string"
+  default     = "us-west-2"
+  description = "AWS Region"
+}
+
+variable "image_id" {
+  type        = "string"
+  default     = "ami-08cab282f9979fc7a"
+  description = "The EC2 image ID to launch"
+}
+
+variable "instance_type" {
+  type        = "string"
+  default     = "t2.small"
+  description = "Instance type to launch"
+}
+
+variable "health_check_type" {
+  type        = "string"
+  default     = "EC2"
+  description = "Controls how health checking is done. Valid values are `EC2` or `ELB`"
+}
+
+variable "wait_for_capacity_timeout" {
+  type        = "string"
+  default     = "10m"
+  description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. (See also Waiting for Capacity below.) Setting this to '0' causes Terraform to skip all Capacity Waiting behavior"
+}
+
+variable "max_size" {
+  default     = 5
+  description = "The maximum size of the autoscale group"
+}
+
+variable "min_size" {
+  default     = 3
+  description = "The minimum size of the autoscale group"
+}
+
+variable "cpu_utilization_high_threshold_percent" {
+  type        = "string"
+  default     = "80"
+  description = "CPU utilization high threshold"
+}
+
+variable "cpu_utilization_low_threshold_percent" {
+  type        = "string"
+  default     = "20"
+  description = "CPU utilization loq threshold"
+}
+
+variable "mixed_type" {
+  type        = "string"
+  default     = "true"
+}
+
+#https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#instances_distribution
+variable "autoscaling_configs" {
+  default = {
+      on_demand_base_capacity = 0
+      spot_instance_pools = 1
+      health_check_grace_period = 300
+      on_demand_percentage_above_base_capacity = 10
+      spot_max_price = ""
+  }
+}
+
+variable "autoscaling_instances" {
+  default = {
+      supported_instance_1 = "t3.medium"
+      supported_instance_2 = "t2.medium"
+      supported_instance_3 = "t3.large"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -162,9 +162,9 @@ resource "aws_autoscaling_group" "default_mixed" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes = [
-      "launch_template",
-      "mixed_instances_policy",
-    ]
+    //ignore_changes = [
+    //  "launch_template",
+    //  "mixed_instances_policy",
+    //]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ data "null_data_source" "tags_as_list_of_maps" {
 }
 
 resource "aws_autoscaling_group" "default" {
-  count = "${var.enabled == "true" ? 1 : 0}"
+  count = "${var.enabled == "true" && var.mixed_type == "false" ? 1 : 0}"
 
   name_prefix               = "${format("%s%s", module.label.id, var.delimiter)}"
   vpc_zone_identifier       = ["${var.subnet_ids}"]
@@ -93,7 +93,7 @@ resource "aws_autoscaling_group" "default" {
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
   protect_from_scale_in     = "${var.protect_from_scale_in}"
   service_linked_role_arn   = "${var.service_linked_role_arn}"
-
+  
   launch_template = {
     id      = "${join("", aws_launch_template.default.*.id)}"
     version = "${aws_launch_template.default.latest_version}"
@@ -103,5 +103,68 @@ resource "aws_autoscaling_group" "default" {
 
   lifecycle {
     create_before_destroy = true
+  }
+}
+
+
+resource "aws_autoscaling_group" "default_mixed" {
+  count = "${var.enabled == "true" && var.mixed_type=="true" ? 1 : 0}"
+
+  name_prefix               = "${format("%s%s", module.label.id, var.delimiter)}"
+  vpc_zone_identifier       = ["${var.subnet_ids}"]
+  max_size                  = "${var.max_size}"
+  min_size                  = "${var.min_size}"
+  load_balancers            = ["${var.load_balancers}"]
+  health_check_grace_period = "${var.health_check_grace_period}"
+  health_check_type         = "${var.health_check_type}"
+  min_elb_capacity          = "${var.min_elb_capacity}"
+  wait_for_elb_capacity     = "${var.wait_for_elb_capacity}"
+  target_group_arns         = ["${var.target_group_arns}"]
+  default_cooldown          = "${var.default_cooldown}"
+  force_delete              = "${var.force_delete}"
+  termination_policies      = "${var.termination_policies}"
+  suspended_processes       = "${var.suspended_processes}"
+  placement_group           = "${var.placement_group}"
+  enabled_metrics           = ["${var.enabled_metrics}"]
+  metrics_granularity       = "${var.metrics_granularity}"
+  wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
+  protect_from_scale_in     = "${var.protect_from_scale_in}"
+  service_linked_role_arn   = "${var.service_linked_role_arn}"
+  
+
+  mixed_instances_policy {
+    instances_distribution {
+      on_demand_base_capacity                  = "${var.autoscaling_configs["on_demand_base_capacity"]}"
+      on_demand_percentage_above_base_capacity = "${var.autoscaling_configs["on_demand_percentage_above_base_capacity"]}"
+      spot_instance_pools                      = "${var.autoscaling_configs["spot_instance_pools"]}"
+      spot_max_price                           = "${var.autoscaling_configs["spot_max_price"]}"
+    }
+
+    launch_template {
+      launch_template_specification {
+        launch_template_id = "${join("", aws_launch_template.default.*.id)}"
+      }
+      override {
+        instance_type = "${var.autoscaling_instances["supported_instance_1"]}"
+      }
+
+      override {
+        instance_type = "${var.autoscaling_instances["supported_instance_2"]}"
+      }
+
+      override {
+        instance_type = "${var.autoscaling_instances["supported_instance_3"]}"
+      }
+    }
+  }
+
+  tags = ["${data.null_data_source.tags_as_list_of_maps.*.outputs}"]
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes = [
+      "launch_template",
+      "mixed_instances_policy",
+    ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -353,3 +353,26 @@ variable "cpu_utilization_low_statistic" {
   default     = "Average"
   description = "The statistic to apply to the alarm's associated metric. Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`"
 }
+
+variable "mixed_type" {
+  type        = "string"
+  default     = "false"
+}
+
+variable "autoscaling_configs" {
+  default = {
+      on_demand_base_capacity = 0
+      spot_instance_pools = 1
+      health_check_grace_period = 300
+      on_demand_percentage_above_base_capacity = 10
+      spot_max_price = ""
+  }
+}
+
+variable "autoscaling_instances" {
+  default = {
+      supported_instance_1 = "t3.medium"
+      supported_instance_2 = "t2.medium"
+      supported_instance_3 = "t3.large"
+  }
+}


### PR DESCRIPTION
I imagine you'll be updating this to tf12 soon so I thought i'd get this in for 0.11 (so I don't have to set fire to the EKS setup) 👍 
Copied the example that was there to test this; as the versions were all set to master I've had to switch them to valid versions (lest I fight trying to test it for ever more)

I've not updated the doc; figured I'd check if it was likely first :)