### PR TITLE
Upgrade to terraform 0.12

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,63 +1,64 @@
 # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html
 
 locals {
-  autoscaling_enabled = "${var.enabled == "true" && var.autoscaling_policies_enabled == "true" ? true : false}"
+  autoscaling_enabled = var.enabled && var.autoscaling_policies_enabled ? true : false
 }
 
 resource "aws_autoscaling_policy" "scale_up" {
-  count                  = "${local.autoscaling_enabled ? 1 : 0}"
+  count                  = local.autoscaling_enabled ? 1 : 0
   name                   = "${module.label.id}${var.delimiter}scale${var.delimiter}up"
-  scaling_adjustment     = "${var.scale_up_scaling_adjustment}"
-  adjustment_type        = "${var.scale_up_adjustment_type}"
-  policy_type            = "${var.scale_up_policy_type}"
-  cooldown               = "${var.scale_up_cooldown_seconds}"
-  autoscaling_group_name = "${join("", aws_autoscaling_group.default.*.name)}"
+  scaling_adjustment     = var.scale_up_scaling_adjustment
+  adjustment_type        = var.scale_up_adjustment_type
+  policy_type            = var.scale_up_policy_type
+  cooldown               = var.scale_up_cooldown_seconds
+  autoscaling_group_name = join("", aws_autoscaling_group.default.*.name)
 }
 
 resource "aws_autoscaling_policy" "scale_down" {
-  count                  = "${local.autoscaling_enabled ? 1 : 0}"
+  count                  = local.autoscaling_enabled ? 1 : 0
   name                   = "${module.label.id}${var.delimiter}scale${var.delimiter}down"
-  scaling_adjustment     = "${var.scale_down_scaling_adjustment}"
-  adjustment_type        = "${var.scale_down_adjustment_type}"
-  policy_type            = "${var.scale_down_policy_type}"
-  cooldown               = "${var.scale_down_cooldown_seconds}"
-  autoscaling_group_name = "${join("", aws_autoscaling_group.default.*.name)}"
+  scaling_adjustment     = var.scale_down_scaling_adjustment
+  adjustment_type        = var.scale_down_adjustment_type
+  policy_type            = var.scale_down_policy_type
+  cooldown               = var.scale_down_cooldown_seconds
+  autoscaling_group_name = join("", aws_autoscaling_group.default.*.name)
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_high" {
-  count               = "${local.autoscaling_enabled ? 1 : 0}"
+  count               = local.autoscaling_enabled ? 1 : 0
   alarm_name          = "${module.label.id}${var.delimiter}cpu${var.delimiter}utilization${var.delimiter}high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "${var.cpu_utilization_high_evaluation_periods}"
+  evaluation_periods  = var.cpu_utilization_high_evaluation_periods
   metric_name         = "CPUUtilization"
   namespace           = "AWS/EC2"
-  period              = "${var.cpu_utilization_high_period_seconds}"
-  statistic           = "${var.cpu_utilization_high_statistic}"
-  threshold           = "${var.cpu_utilization_high_threshold_percent}"
+  period              = var.cpu_utilization_high_period_seconds
+  statistic           = var.cpu_utilization_high_statistic
+  threshold           = var.cpu_utilization_high_threshold_percent
 
-  dimensions {
-    AutoScalingGroupName = "${join("", aws_autoscaling_group.default.*.name)}"
+  dimensions = {
+    AutoScalingGroupName = join("", aws_autoscaling_group.default.*.name)
   }
 
   alarm_description = "Scale up if CPU utilization is above ${var.cpu_utilization_high_threshold_percent} for ${var.cpu_utilization_high_period_seconds} seconds"
-  alarm_actions     = ["${join("", aws_autoscaling_policy.scale_up.*.arn)}"]
+  alarm_actions     = [join("", aws_autoscaling_policy.scale_up.*.arn)]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_low" {
-  count               = "${local.autoscaling_enabled ? 1 : 0}"
+  count               = local.autoscaling_enabled ? 1 : 0
   alarm_name          = "${module.label.id}${var.delimiter}cpu${var.delimiter}utilization${var.delimiter}low"
   comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "${var.cpu_utilization_low_evaluation_periods}"
+  evaluation_periods  = var.cpu_utilization_low_evaluation_periods
   metric_name         = "CPUUtilization"
   namespace           = "AWS/EC2"
-  period              = "${var.cpu_utilization_low_period_seconds}"
-  statistic           = "${var.cpu_utilization_low_statistic}"
-  threshold           = "${var.cpu_utilization_low_threshold_percent}"
+  period              = var.cpu_utilization_low_period_seconds
+  statistic           = var.cpu_utilization_low_statistic
+  threshold           = var.cpu_utilization_low_threshold_percent
 
-  dimensions {
-    AutoScalingGroupName = "${join("", aws_autoscaling_group.default.*.name)}"
+  dimensions = {
+    AutoScalingGroupName = join("", aws_autoscaling_group.default.*.name)
   }
 
   alarm_description = "Scale down if the CPU utilization is below ${var.cpu_utilization_low_threshold_percent} for ${var.cpu_utilization_low_period_seconds} seconds"
-  alarm_actions     = ["${join("", aws_autoscaling_policy.scale_down.*.arn)}"]
+  alarm_actions     = [join("", aws_autoscaling_policy.scale_down.*.arn)]
 }
+

--- a/main.tf
+++ b/main.tf
@@ -1,59 +1,115 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  stage      = "${var.stage}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
-  enabled    = "${var.enabled}"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
+  enabled    = var.enabled
 }
 
 resource "aws_launch_template" "default" {
-  count = "${var.enabled == "true" ? 1 : 0}"
+  count = var.enabled ? 1 : 0
 
-  name_prefix                          = "${format("%s%s", module.label.id, var.delimiter)}"
-  block_device_mappings                = ["${var.block_device_mappings}"]
-  credit_specification                 = ["${var.credit_specification}"]
-  disable_api_termination              = "${var.disable_api_termination}"
-  ebs_optimized                        = "${var.ebs_optimized}"
-  elastic_gpu_specifications           = ["${var.elastic_gpu_specifications}"]
-  image_id                             = "${var.image_id}"
-  instance_initiated_shutdown_behavior = "${var.instance_initiated_shutdown_behavior}"
-  instance_market_options              = ["${var.instance_market_options }"]
-  instance_type                        = "${var.instance_type}"
-  key_name                             = "${var.key_name}"
-  placement                            = ["${var.placement}"]
-  user_data                            = "${var.user_data_base64}"
+  name_prefix = format("%s%s", module.label.id, var.delimiter)
+  dynamic "block_device_mappings" {
+    for_each = var.block_device_mappings
+    content {
+      device_name  = lookup(block_device_mappings.value, "device_name", null)
+      no_device    = lookup(block_device_mappings.value, "no_device", null)
+      virtual_name = lookup(block_device_mappings.value, "virtual_name", null)
+
+      dynamic "ebs" {
+        for_each = [lookup(block_device_mappings.value, "ebs", null)]
+        content {
+          delete_on_termination = lookup(ebs.value, "delete_on_termination", null)
+          encrypted             = lookup(ebs.value, "encrypted", null)
+          iops                  = lookup(ebs.value, "iops", null)
+          kms_key_id            = lookup(ebs.value, "kms_key_id", null)
+          snapshot_id           = lookup(ebs.value, "snapshot_id", null)
+          volume_size           = lookup(ebs.value, "volume_size", null)
+          volume_type           = lookup(ebs.value, "volume_type", null)
+        }
+      }
+    }
+  }
+  dynamic "credit_specification" {
+    for_each = var.credit_specification
+    content {
+      cpu_credits = lookup(credit_specification.value, "cpu_credits", null)
+    }
+  }
+  disable_api_termination = var.disable_api_termination
+  ebs_optimized           = var.ebs_optimized
+  dynamic "elastic_gpu_specifications" {
+    for_each = var.elastic_gpu_specifications
+    content {
+      type = elastic_gpu_specifications.value.type
+    }
+  }
+  image_id                             = var.image_id
+  instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
+  dynamic "instance_market_options" {
+    for_each = var.instance_market_options
+    content {
+      market_type = lookup(instance_market_options.value, "market_type", null)
+
+      dynamic "spot_options" {
+        for_each = [lookup(instance_market_options.value, "spot_options", null)]
+        content {
+          block_duration_minutes         = lookup(spot_options.value, "block_duration_minutes", null)
+          instance_interruption_behavior = lookup(spot_options.value, "instance_interruption_behavior", null)
+          max_price                      = lookup(spot_options.value, "max_price", null)
+          spot_instance_type             = lookup(spot_options.value, "spot_instance_type", null)
+          valid_until                    = lookup(spot_options.value, "valid_until", null)
+        }
+      }
+    }
+  }
+  instance_type = var.instance_type
+  key_name      = var.key_name
+  dynamic "placement" {
+    for_each = var.placement
+    content {
+      affinity          = lookup(placement.value, "affinity", null)
+      availability_zone = lookup(placement.value, "availability_zone", null)
+      group_name        = lookup(placement.value, "group_name", null)
+      host_id           = lookup(placement.value, "host_id", null)
+      spread_domain     = lookup(placement.value, "spread_domain", null)
+      tenancy           = lookup(placement.value, "tenancy", null)
+    }
+  }
+  user_data = var.user_data_base64
 
   iam_instance_profile {
-    name = "${var.iam_instance_profile_name}"
+    name = var.iam_instance_profile_name
   }
 
   monitoring {
-    enabled = "${var.enable_monitoring}"
+    enabled = var.enable_monitoring
   }
 
   # https://github.com/terraform-providers/terraform-provider-aws/issues/4570
   network_interfaces {
-    description                 = "${module.label.id}"
+    description                 = module.label.id
     device_index                = 0
-    associate_public_ip_address = "${var.associate_public_ip_address}"
+    associate_public_ip_address = var.associate_public_ip_address
     delete_on_termination       = true
-    security_groups             = ["${var.security_group_ids}"]
+    security_groups             = var.security_group_ids
   }
 
   tag_specifications {
     resource_type = "volume"
-    tags          = "${module.label.tags}"
+    tags          = module.label.tags
   }
 
   tag_specifications {
     resource_type = "instance"
-    tags          = "${module.label.tags}"
+    tags          = module.label.tags
   }
 
-  tags = "${module.label.tags}"
+  tags = module.label.tags
 
   lifecycle {
     create_before_destroy = true
@@ -61,47 +117,48 @@ resource "aws_launch_template" "default" {
 }
 
 data "null_data_source" "tags_as_list_of_maps" {
-  count = "${var.enabled == "true" ? length(keys(var.tags)) : 0}"
+  count = var.enabled ? length(keys(var.tags)) : 0
 
-  inputs = "${map(
-    "key", "${element(keys(var.tags), count.index)}",
-    "value", "${element(values(var.tags), count.index)}",
-    "propagate_at_launch", true
-  )}"
+  inputs = {
+    "key"                 = element(keys(var.tags), count.index)
+    "value"               = element(values(var.tags), count.index)
+    "propagate_at_launch" = true
+  }
 }
 
 resource "aws_autoscaling_group" "default" {
-  count = "${var.enabled == "true" ? 1 : 0}"
+  count = var.enabled ? 1 : 0
 
-  name_prefix               = "${format("%s%s", module.label.id, var.delimiter)}"
-  vpc_zone_identifier       = ["${var.subnet_ids}"]
-  max_size                  = "${var.max_size}"
-  min_size                  = "${var.min_size}"
-  load_balancers            = ["${var.load_balancers}"]
-  health_check_grace_period = "${var.health_check_grace_period}"
-  health_check_type         = "${var.health_check_type}"
-  min_elb_capacity          = "${var.min_elb_capacity}"
-  wait_for_elb_capacity     = "${var.wait_for_elb_capacity}"
-  target_group_arns         = ["${var.target_group_arns}"]
-  default_cooldown          = "${var.default_cooldown}"
-  force_delete              = "${var.force_delete}"
-  termination_policies      = "${var.termination_policies}"
-  suspended_processes       = "${var.suspended_processes}"
-  placement_group           = "${var.placement_group}"
-  enabled_metrics           = ["${var.enabled_metrics}"]
-  metrics_granularity       = "${var.metrics_granularity}"
-  wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
-  protect_from_scale_in     = "${var.protect_from_scale_in}"
-  service_linked_role_arn   = "${var.service_linked_role_arn}"
+  name_prefix               = format("%s%s", module.label.id, var.delimiter)
+  vpc_zone_identifier       = var.subnet_ids
+  max_size                  = var.max_size
+  min_size                  = var.min_size
+  load_balancers            = var.load_balancers
+  health_check_grace_period = var.health_check_grace_period
+  health_check_type         = var.health_check_type
+  min_elb_capacity          = var.min_elb_capacity
+  wait_for_elb_capacity     = var.wait_for_elb_capacity
+  target_group_arns         = var.target_group_arns
+  default_cooldown          = var.default_cooldown
+  force_delete              = var.force_delete
+  termination_policies      = var.termination_policies
+  suspended_processes       = var.suspended_processes
+  placement_group           = var.placement_group
+  enabled_metrics           = var.enabled_metrics
+  metrics_granularity       = var.metrics_granularity
+  wait_for_capacity_timeout = var.wait_for_capacity_timeout
+  protect_from_scale_in     = var.protect_from_scale_in
+  service_linked_role_arn   = var.service_linked_role_arn
 
-  launch_template = {
-    id      = "${join("", aws_launch_template.default.*.id)}"
-    version = "${aws_launch_template.default.latest_version}"
+  launch_template {
+    id      = join("", aws_launch_template.default.*.id)
+    version = aws_launch_template.default[0].latest_version
   }
 
-  tags = ["${data.null_data_source.tags_as_list_of_maps.*.outputs}"]
+  tags = data.null_data_source.tags_as_list_of_maps.*.outputs
 
   lifecycle {
     create_before_destroy = true
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,54 +1,58 @@
 output "launch_template_id" {
   description = "The ID of the launch template"
-  value       = "${join("", aws_launch_template.default.*.id)}"
+  value       = join("", aws_launch_template.default.*.id)
 }
 
 output "launch_template_arn" {
   description = "The ARN of the launch template"
-  value       = "${join("", aws_launch_template.default.*.arn)}"
+  value       = join("", aws_launch_template.default.*.arn)
 }
 
 output "autoscaling_group_id" {
   description = "The autoscaling group id"
-  value       = "${join("", aws_autoscaling_group.default.*.id)}"
+  value       = join("", aws_autoscaling_group.default.*.id)
 }
 
 output "autoscaling_group_name" {
   description = "The autoscaling group name"
-  value       = "${join("", aws_autoscaling_group.default.*.name)}"
+  value       = join("", aws_autoscaling_group.default.*.name)
 }
 
 output "autoscaling_group_arn" {
   description = "The ARN for this AutoScaling Group"
-  value       = "${join("", aws_autoscaling_group.default.*.arn)}"
+  value       = join("", aws_autoscaling_group.default.*.arn)
 }
 
 output "autoscaling_group_min_size" {
   description = "The minimum size of the autoscale group"
-  value       = "${join("", aws_autoscaling_group.default.*.min_size)}"
+  value       = join("", aws_autoscaling_group.default.*.min_size)
 }
 
 output "autoscaling_group_max_size" {
   description = "The maximum size of the autoscale group"
-  value       = "${join("", aws_autoscaling_group.default.*.max_size)}"
+  value       = join("", aws_autoscaling_group.default.*.max_size)
 }
 
 output "autoscaling_group_desired_capacity" {
   description = "The number of Amazon EC2 instances that should be running in the group"
-  value       = "${join("", aws_autoscaling_group.default.*.desired_capacity)}"
+  value       = join("", aws_autoscaling_group.default.*.desired_capacity)
 }
 
 output "autoscaling_group_default_cooldown" {
   description = "Time between a scaling activity and the succeeding scaling activity"
-  value       = "${join("", aws_autoscaling_group.default.*.default_cooldown)}"
+  value       = join("", aws_autoscaling_group.default.*.default_cooldown)
 }
 
 output "autoscaling_group_health_check_grace_period" {
   description = "Time after instance comes into service before checking health"
-  value       = "${join("", aws_autoscaling_group.default.*.health_check_grace_period)}"
+  value = join(
+    "",
+    aws_autoscaling_group.default.*.health_check_grace_period,
+  )
 }
 
 output "autoscaling_group_health_check_type" {
   description = "`EC2` or `ELB`. Controls how health checking is done"
-  value       = "${join("", aws_autoscaling_group.default.*.health_check_type)}"
+  value       = join("", aws_autoscaling_group.default.*.health_check_type)
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,142 +1,179 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace, which could be your organization name, e.g. 'eg' or 'cp'"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
 }
 
 variable "environment" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Environment, e.g. 'testing', 'UAT'"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   default     = "app"
   description = "Solution name, e.g. 'app' or 'cluster'"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
 }
 
 variable "enabled" {
-  type        = "string"
+  type        = bool
   description = "Whether to create the resources. Set to `false` to prevent the module from creating any resources"
-  default     = "true"
+  default     = true
 }
 
 variable "image_id" {
-  type        = "string"
+  type        = string
   description = "The EC2 image ID to launch"
   default     = ""
 }
 
 variable "instance_initiated_shutdown_behavior" {
-  type        = "string"
+  type        = string
   description = "Shutdown behavior for the instances. Can be `stop` or `terminate`"
   default     = "terminate"
 }
 
 variable "instance_type" {
-  type        = "string"
+  type        = string
   description = "Instance type to launch"
 }
 
 variable "iam_instance_profile_name" {
-  type        = "string"
+  type        = string
   description = "The IAM instance profile name to associate with launched instances"
   default     = ""
 }
 
 variable "key_name" {
-  type        = "string"
+  type        = string
   description = "The SSH key name that should be used for the instance"
   default     = ""
 }
 
 variable "security_group_ids" {
   description = "A list of associated security group IDs"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "launch_template_version" {
-  type        = "string"
+  type        = string
   description = "Launch template version. Can be version number, `$Latest` or `$Default`"
   default     = "$Latest"
 }
 
 variable "associate_public_ip_address" {
+  type        = bool
   description = "Associate a public IP address with an instance in a VPC"
   default     = false
 }
 
 variable "user_data_base64" {
-  type        = "string"
+  type        = string
   description = "The Base64-encoded user data to provide when launching the instances"
   default     = ""
 }
 
 variable "enable_monitoring" {
+  type        = bool
   description = "Enable/disable detailed monitoring"
   default     = true
 }
 
 variable "ebs_optimized" {
+  type        = bool
   description = "If true, the launched EC2 instance will be EBS-optimized"
   default     = false
 }
 
 variable "block_device_mappings" {
   description = "Specify volumes to attach to the instance besides the volumes specified by the AMI"
-  type        = "list"
-  default     = []
+  type = list(object({
+    device_name  = string,
+    no_device    = string,
+    virtual_name = string,
+    ebs = object({
+      delete_on_termination = bool,
+      encrypted             = bool,
+      iops                  = number,
+      kms_key_id            = string,
+      snapshot_id           = string,
+      volume_size           = string,
+      volume_type           = string
+    })
+  }))
+  default = []
 }
 
 variable "instance_market_options" {
   description = "The market (purchasing) option for the instances"
-  type        = "list"
-  default     = []
+  type = list(object({
+    market_type = string,
+    spot_options = object({
+      block_duration_minutes         = number,
+      instance_interruption_behavior = string,
+      max_price                      = string,
+      spot_instance_type             = string,
+      valid_until                    = string,
+    })
+  }))
+  default = []
 }
 
 variable "placement" {
   description = "The placement specifications of the instances"
-  type        = "list"
-  default     = []
+  type = list(object({
+    affinity          = string,
+    availability_zone = string,
+    group_name        = string,
+    host_id           = string,
+    spread_domain     = string,
+    tenancy           = string
+  }))
+  default = []
 }
 
 variable "credit_specification" {
   description = "Customize the credit specification of the instances"
-  type        = "list"
-  default     = []
+  type = list(object({
+    cpu_credits = string
+  }))
+  default = []
 }
 
 variable "elastic_gpu_specifications" {
   description = "Specifications of Elastic GPU to attach to the instances"
-  type        = "list"
-  default     = []
+  type = list(object({
+    type = string
+  }))
+  default = []
 }
 
 variable "disable_api_termination" {
+  type        = bool
   description = "If `true`, enables EC2 Instance Termination Protection"
   default     = false
 }
@@ -151,7 +188,7 @@ variable "min_size" {
 
 variable "subnet_ids" {
   description = "A list of subnet IDs to launch resources in"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "default_cooldown" {
@@ -165,55 +202,56 @@ variable "health_check_grace_period" {
 }
 
 variable "health_check_type" {
-  type        = "string"
+  type        = string
   description = "Controls how health checking is done. Valid values are `EC2` or `ELB`"
   default     = "EC2"
 }
 
 variable "force_delete" {
+  type        = bool
   description = "Allows deleting the autoscaling group without waiting for all instances in the pool to terminate. You can force an autoscaling group to delete even if it's in the process of scaling a resource. Normally, Terraform drains all the instances before deleting the group. This bypasses that behavior and potentially leaves resources dangling"
   default     = false
 }
 
 variable "load_balancers" {
-  type        = "list"
+  type        = list(string)
   description = "A list of elastic load balancer names to add to the autoscaling group names. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead"
   default     = []
 }
 
 variable "target_group_arns" {
-  type        = "list"
+  type        = list(string)
   description = "A list of aws_alb_target_group ARNs, for use with Application Load Balancing"
   default     = []
 }
 
 variable "termination_policies" {
   description = "A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default`"
-  type        = "list"
+  type        = list(string)
   default     = ["Default"]
 }
 
 variable "suspended_processes" {
-  type        = "list"
+  type        = list(string)
   description = "A list of processes to suspend for the AutoScaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`. Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your autoscaling group from functioning properly."
   default     = []
 }
 
 variable "placement_group" {
-  type        = "string"
+  type        = string
   description = "The name of the placement group into which you'll launch your instances, if any"
   default     = ""
 }
 
 variable "metrics_granularity" {
-  type        = "string"
+  type        = string
   description = "The granularity to associate with the metrics to collect. The only valid value is 1Minute"
   default     = "1Minute"
 }
 
 variable "enabled_metrics" {
   description = "A list of metrics to collect. The allowed values are `GroupMinSize`, `GroupMaxSize`, `GroupDesiredCapacity`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupTerminatingInstances`, `GroupTotalInstances`"
-  type        = "list"
+  type        = list(string)
 
   default = [
     "GroupMinSize",
@@ -228,7 +266,7 @@ variable "enabled_metrics" {
 }
 
 variable "wait_for_capacity_timeout" {
-  type        = "string"
+  type        = string
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior"
   default     = "10m"
 }
@@ -239,29 +277,31 @@ variable "min_elb_capacity" {
 }
 
 variable "wait_for_elb_capacity" {
+  type        = number
   description = "Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior"
-  default     = false
+  default     = null
 }
 
 variable "protect_from_scale_in" {
+  type        = bool
   description = "Allows setting instance protection. The autoscaling group will not select instances with this setting for terminination during scale in events"
   default     = false
 }
 
 variable "service_linked_role_arn" {
-  type        = "string"
+  type        = string
   description = "The ARN of the service-linked role that the ASG will use to call other AWS services"
   default     = ""
 }
 
 variable "autoscaling_policies_enabled" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Whether to create `aws_autoscaling_policy` and `aws_cloudwatch_metric_alarm` resources to control Auto Scaling"
 }
 
 variable "scale_up_cooldown_seconds" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start"
 }
@@ -272,19 +312,19 @@ variable "scale_up_scaling_adjustment" {
 }
 
 variable "scale_up_adjustment_type" {
-  type        = "string"
+  type        = string
   default     = "ChangeInCapacity"
   description = "Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity` and `PercentChangeInCapacity`"
 }
 
 variable "scale_up_policy_type" {
-  type        = "string"
+  type        = string
   default     = "SimpleScaling"
   description = "The scalling policy type, either `SimpleScaling`, `StepScaling` or `TargetTrackingScaling`"
 }
 
 variable "scale_down_cooldown_seconds" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start"
 }
@@ -295,61 +335,62 @@ variable "scale_down_scaling_adjustment" {
 }
 
 variable "scale_down_adjustment_type" {
-  type        = "string"
+  type        = string
   default     = "ChangeInCapacity"
   description = "Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity` and `PercentChangeInCapacity`"
 }
 
 variable "scale_down_policy_type" {
-  type        = "string"
+  type        = string
   default     = "SimpleScaling"
   description = "The scalling policy type, either `SimpleScaling`, `StepScaling` or `TargetTrackingScaling`"
 }
 
 variable "cpu_utilization_high_evaluation_periods" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "The number of periods over which data is compared to the specified threshold"
 }
 
 variable "cpu_utilization_high_period_seconds" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "The period in seconds over which the specified statistic is applied"
 }
 
 variable "cpu_utilization_high_threshold_percent" {
-  type        = "string"
+  type        = string
   default     = "90"
   description = "The value against which the specified statistic is compared"
 }
 
 variable "cpu_utilization_high_statistic" {
-  type        = "string"
+  type        = string
   default     = "Average"
   description = "The statistic to apply to the alarm's associated metric. Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`"
 }
 
 variable "cpu_utilization_low_evaluation_periods" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "The number of periods over which data is compared to the specified threshold"
 }
 
 variable "cpu_utilization_low_period_seconds" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "The period in seconds over which the specified statistic is applied"
 }
 
 variable "cpu_utilization_low_threshold_percent" {
-  type        = "string"
+  type        = string
   default     = "10"
   description = "The value against which the specified statistic is compared"
 }
 
 variable "cpu_utilization_low_statistic" {
-  type        = "string"
+  type        = string
   default     = "Average"
   description = "The statistic to apply to the alarm's associated metric. Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This moves us to terraform 0.12, it is working with our usages of this module, but it hasn't been tested completely with all options, but does appear valid.

note that the examples aren't ported yet, as some of the modules it uses aren't yet ported.

It also does not implement the testing that is getting added