### PR TITLE
fixing block_duration_minutes var type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -132,7 +132,7 @@ variable "instance_market_options" {
   type = object({
     market_type = string
     spot_options = object({
-      block_duration_minutes         = bool
+      block_duration_minutes         = number
       instance_interruption_behavior = string
       max_price                      = number
       spot_instance_type             = string


### PR DESCRIPTION
block_duration_minutes should be of number type
https://www.terraform.io/docs/providers/aws/r/launch_template.html#block_duration_minutes