### PR TITLE
fix: update aws provider version for dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,13 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
 
@@ -144,7 +145,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -229,6 +230,7 @@ Available targets:
 | launch\_template\_arn | The ARN of the launch template |
 | launch\_template\_id | The ID of the launch template |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,9 +1,10 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
 
@@ -11,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -96,3 +97,4 @@
 | launch\_template\_arn | The ARN of the launch template |
 | launch\_template\_id | The ID of the launch template |
 
+<!-- markdownlint-restore -->

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = "~> 2.0"
+    aws      = "~> 3.0"
     template = "~> 2.0"
     null     = "~> 2.0"
   }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = "~> 3.0"
+    aws      = ">= 2.0"
     template = "~> 2.0"
     null     = "~> 2.0"
   }


### PR DESCRIPTION
## what
* Update `aws` provider to 3.0 avoid module version conflicts

## why

* This module is being used by https://github.com/cloudposse/terraform-aws-eks-workers, which will cause issues if also being used by modules requiring the 3.0 `aws` provider

## references
* See https://github.com/cloudposse/terraform-aws-eks-workers/issues/46 for more info on the upstream usage issue

