### PR TITLE
allow setting label order

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Available targets:
 | instance\_market\_options | The market (purchasing) option for the instances | <pre>object({<br>    market_type = string<br>    spot_options = object({<br>      block_duration_minutes         = number<br>      instance_interruption_behavior = string<br>      max_price                      = number<br>      spot_instance_type             = string<br>      valid_until                    = string<br>    })<br>  })</pre> | `null` | no |
 | instance\_type | Instance type to launch | `string` | n/a | yes |
 | key\_name | The SSH key name that should be used for the instance | `string` | `""` | no |
+| label\_order | The order of the label components. Defaults to the module default. | `list(string)` | `null` | no |
 | launch\_template\_version | Launch template version. Can be version number, `$Latest` or `$Default` | `string` | `"$Latest"` | no |
 | load\_balancers | A list of elastic load balancer names to add to the autoscaling group names. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead | `list(string)` | `[]` | no |
 | max\_size | The maximum size of the autoscale group | `number` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Available targets:
 | instance\_market\_options | The market (purchasing) option for the instances | <pre>object({<br>    market_type = string<br>    spot_options = object({<br>      block_duration_minutes         = number<br>      instance_interruption_behavior = string<br>      max_price                      = number<br>      spot_instance_type             = string<br>      valid_until                    = string<br>    })<br>  })</pre> | `null` | no |
 | instance\_type | Instance type to launch | `string` | n/a | yes |
 | key\_name | The SSH key name that should be used for the instance | `string` | `""` | no |
-| label\_order | The order of the label components. Defaults to the module default. | `list(string)` | `null` | no |
+| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | launch\_template\_version | Launch template version. Can be version number, `$Latest` or `$Default` | `string` | `"$Latest"` | no |
 | load\_balancers | A list of elastic load balancer names to add to the autoscaling group names. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead | `list(string)` | `[]` | no |
 | max\_size | The maximum size of the autoscale group | `number` | n/a | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -49,7 +49,7 @@
 | instance\_market\_options | The market (purchasing) option for the instances | <pre>object({<br>    market_type = string<br>    spot_options = object({<br>      block_duration_minutes         = number<br>      instance_interruption_behavior = string<br>      max_price                      = number<br>      spot_instance_type             = string<br>      valid_until                    = string<br>    })<br>  })</pre> | `null` | no |
 | instance\_type | Instance type to launch | `string` | n/a | yes |
 | key\_name | The SSH key name that should be used for the instance | `string` | `""` | no |
-| label\_order | The order of the label components. Defaults to the module default. | `list(string)` | `null` | no |
+| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | launch\_template\_version | Launch template version. Can be version number, `$Latest` or `$Default` | `string` | `"$Latest"` | no |
 | load\_balancers | A list of elastic load balancer names to add to the autoscaling group names. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead | `list(string)` | `[]` | no |
 | max\_size | The maximum size of the autoscale group | `number` | n/a | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -49,6 +49,7 @@
 | instance\_market\_options | The market (purchasing) option for the instances | <pre>object({<br>    market_type = string<br>    spot_options = object({<br>      block_duration_minutes         = number<br>      instance_interruption_behavior = string<br>      max_price                      = number<br>      spot_instance_type             = string<br>      valid_until                    = string<br>    })<br>  })</pre> | `null` | no |
 | instance\_type | Instance type to launch | `string` | n/a | yes |
 | key\_name | The SSH key name that should be used for the instance | `string` | `""` | no |
+| label\_order | The order of the label components. Defaults to the module default. | `list(string)` | `null` | no |
 | launch\_template\_version | Launch template version. Can be version number, `$Latest` or `$Default` | `string` | `"$Latest"` | no |
 | load\_balancers | A list of elastic load balancer names to add to the autoscaling group names. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead | `list(string)` | `[]` | no |
 | max\_size | The maximum size of the autoscale group | `number` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
   namespace   = var.namespace
   name        = var.name
   stage       = var.stage

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ module "label" {
   name        = var.name
   stage       = var.stage
   environment = var.environment
+  label_order = var.label_order
   delimiter   = var.delimiter
   attributes  = var.attributes
   tags        = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,11 @@ variable "name" {
 variable "label_order" {
   type        = list(string)
   default     = null
-  description = "The order of the label components. Defaults to the module default."
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+  EOT
 }
 
 variable "delimiter" {

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "name" {
   description = "Solution name, e.g. 'app' or 'cluster'"
 }
 
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = "The order of the label components. Defaults to the module default."
+}
+
 variable "delimiter" {
   type        = string
   default     = "-"


### PR DESCRIPTION
I find this module very useful, but there doesn't seem to be a way to change the way resources are named, and the default doesn't match our naming convention. This PR simply passes the `label_order` variable to the **terraform-null-label** module. If left undefined, the current default will continue to be used.


