### PR TITLE
Default alarms require autoscaling policies

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -64,7 +64,7 @@ locals {
     }
   }
 
-  default_alarms = var.default_alarms_enabled ? local.default_ec2_alarms : {}
+  default_alarms = var.autoscaling_policies_enabled && var.default_alarms_enabled ? local.default_ec2_alarms : {}
   all_alarms     = module.this.enabled ? merge(local.default_alarms, var.custom_alarms) : {}
 }
 


### PR DESCRIPTION
## what
* Since the default alarms require autoscaling policies to prefill the alarm_names, both alarms and autoscaling policies need to be enabled

## why
* Applies will fail if autoscaling policies are disabled but default alarms are left enabled

## references
N/A

