### PR TITLE
Desired capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Available targets:
 | default\_alarms\_enabled | Enable or disable cpu and memory Cloudwatch alarms | `bool` | `true` | no |
 | default\_cooldown | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | `number` | `300` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| desired\_capacity | The desired capacity of the autoscale group | `number` | `null` | no |
 | disable\_api\_termination | If `true`, enables EC2 Instance Termination Protection | `bool` | `false` | no |
 | ebs\_optimized | If true, the launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
 | elastic\_gpu\_specifications | Specifications of Elastic GPU to attach to the instances | <pre>object({<br>    type = string<br>  })</pre> | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -52,6 +52,7 @@
 | default\_alarms\_enabled | Enable or disable cpu and memory Cloudwatch alarms | `bool` | `true` | no |
 | default\_cooldown | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | `number` | `300` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| desired\_capacity | The desired capacity of the autoscale group | `number` | `null` | no |
 | disable\_api\_termination | If `true`, enables EC2 Instance Termination Protection | `bool` | `false` | no |
 | ebs\_optimized | If true, the launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
 | elastic\_gpu\_specifications | Specifications of Elastic GPU to attach to the instances | <pre>object({<br>    type = string<br>  })</pre> | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -137,6 +137,7 @@ resource "aws_autoscaling_group" "default" {
   vpc_zone_identifier       = var.subnet_ids
   max_size                  = var.max_size
   min_size                  = var.min_size
+  desired_capacity          = var.desired_capacity
   load_balancers            = var.load_balancers
   health_check_grace_period = var.health_check_grace_period
   health_check_type         = var.health_check_type

--- a/variables.tf
+++ b/variables.tf
@@ -425,3 +425,9 @@ variable "custom_alarms" {
   default     = {}
   description = "Map of custom CloudWatch alarms configurations"
 }
+
+variable "desired_capacity" {
+  type        = number
+  description = "The desired capacity of the autoscale group"
+  default     = null
+}


### PR DESCRIPTION
## what
* Creates a `var.desired_capacity` input

## why
* Nice to be able to set the desired capacity in case we want to set a number between the min and max

## references
* Closes https://github.com/cloudposse/terraform-aws-ec2-autoscale-group/issues/29

... Edit: just realized that this PR already exists! https://github.com/cloudposse/terraform-aws-ec2-autoscale-group/pull/37
