### PR TITLE
set desired_capacity in aws_autoscaling_group as optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,6 @@ locals {
       launch_template        = local.launch_template_block
       override               = var.mixed_instances_policy.override
   })
-  desired_capacity = var.desired_capacity == null ? var.min_size : var.desired_capacity
 }
 
 resource "aws_autoscaling_group" "default" {
@@ -164,7 +163,7 @@ resource "aws_autoscaling_group" "default" {
   wait_for_capacity_timeout = var.wait_for_capacity_timeout
   protect_from_scale_in     = var.protect_from_scale_in
   service_linked_role_arn   = var.service_linked_role_arn
-  desired_capacity          = local.desired_capacity
+  desired_capacity          = var.desired_capacity
   max_instance_lifetime     = var.max_instance_lifetime
 
   dynamic "instance_refresh" {


### PR DESCRIPTION
## what
* set desired_capacity in aws_autoscaling_group as optional

## why
* When auto-scaling is set to 2 and updating asg, the number of instances drops to the minimum value

## references
* #66

