### PR TITLE
Add `warm_pool`

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Available targets:
 | <a name="input_user_data_base64"></a> [user\_data\_base64](#input\_user\_data\_base64) | The Base64-encoded user data to provide when launching the instances | `string` | `""` | no |
 | <a name="input_wait_for_capacity_timeout"></a> [wait\_for\_capacity\_timeout](#input\_wait\_for\_capacity\_timeout) | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | `string` | `"10m"` | no |
 | <a name="input_wait_for_elb_capacity"></a> [wait\_for\_elb\_capacity](#input\_wait\_for\_elb\_capacity) | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | `number` | `0` | no |
+| <a name="input_warm_pool"></a> [warm\_pool](#input\_warm\_pool) | If this block is configured, add a Warm Pool to the specified Auto Scaling group. See [warm\_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#warm_pool). | <pre>object({<br>    pool_state                  = string<br>    min_size                    = number<br>    max_group_prepared_capacity = number<br>  })</pre> | `null` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -112,6 +112,7 @@
 | <a name="input_user_data_base64"></a> [user\_data\_base64](#input\_user\_data\_base64) | The Base64-encoded user data to provide when launching the instances | `string` | `""` | no |
 | <a name="input_wait_for_capacity_timeout"></a> [wait\_for\_capacity\_timeout](#input\_wait\_for\_capacity\_timeout) | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | `string` | `"10m"` | no |
 | <a name="input_wait_for_elb_capacity"></a> [wait\_for\_elb\_capacity](#input\_wait\_for\_elb\_capacity) | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | `number` | `0` | no |
+| <a name="input_warm_pool"></a> [warm\_pool](#input\_warm\_pool) | If this block is configured, add a Warm Pool to the specified Auto Scaling group. See [warm\_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#warm_pool). | <pre>object({<br>    pool_state                  = string<br>    min_size                    = number<br>    max_group_prepared_capacity = number<br>  })</pre> | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -225,7 +225,7 @@ resource "aws_autoscaling_group" "default" {
       }
     }
   }
-  
+
   dynamic "warm_pool" {
     for_each = var.warm_pool != null ? [var.warm_pool] : []
     content {

--- a/main.tf
+++ b/main.tf
@@ -225,6 +225,15 @@ resource "aws_autoscaling_group" "default" {
       }
     }
   }
+  
+  dynamic "warm_pool" {
+    for_each = var.warm_pool != null ? [1] : []
+    content {
+      pool_state                  = var.warm_pool.pool_state
+      min_size                    = var.warm_pool.min_size
+      max_group_prepared_capacity = var.warm_pool.max_group_prepared_capacity
+    }
+  }
 
   tags = flatten([
     for key in keys(module.this.tags) :

--- a/main.tf
+++ b/main.tf
@@ -227,11 +227,11 @@ resource "aws_autoscaling_group" "default" {
   }
   
   dynamic "warm_pool" {
-    for_each = var.warm_pool != null ? [1] : []
+    for_each = var.warm_pool != null ? [var.warm_pool] : []
     content {
-      pool_state                  = var.warm_pool.pool_state
-      min_size                    = var.warm_pool.min_size
-      max_group_prepared_capacity = var.warm_pool.max_group_prepared_capacity
+      pool_state                  = try(warm_pool.value.pool_state, null)
+      min_size                    = try(warm_pool.value.min_size, null)
+      max_group_prepared_capacity = try(warm_pool.value.max_group_prepared_capacity, null)
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -466,11 +466,11 @@ variable "max_instance_lifetime" {
 }
 
 variable "warm_pool" {
-  type        = map(object({
+  type        = object({
     pool_state                  = string
     min_size                    = number
     max_group_prepared_capacity = number
-  }))
+  })
   description = "If this block is configured, add a Warm Pool to the specified Auto Scaling group. See [warm_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#warm_pool)."
-  default     = {}
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -465,3 +465,12 @@ variable "max_instance_lifetime" {
   description = "The maximum amount of time, in seconds, that an instance can be in service, values must be either equal to 0 or between 604800 and 31536000 seconds"
 }
 
+variable "warm_pool" {
+  type        = map(object({
+    pool_state                  = string
+    min_size                    = number
+    max_group_prepared_capacity = number
+  }))
+  description = "If this block is configured, add a Warm Pool to the specified Auto Scaling group. See [warm_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#warm_pool)."
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -466,7 +466,7 @@ variable "max_instance_lifetime" {
 }
 
 variable "warm_pool" {
-  type        = object({
+  type = object({
     pool_state                  = string
     min_size                    = number
     max_group_prepared_capacity = number


### PR DESCRIPTION
## what
* Add `warm_pool`

## why
> A warm pool gives you the ability to decrease latency for your applications that have exceptionally long boot times, for example, because instances need to write massive amounts of data to disk. With warm pools, you no longer have to over-provision your Auto Scaling groups to manage latency in order to improve application performance. 

## references
* https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html

## notes

All inputs have to be provided e.g.

This works
```hcl
  warm_pool = {
    pool_state                  = "Running"
    min_size                    = 1
    max_group_prepared_capacity = null
  }
```

This fails
```hcl
  warm_pool = {
    pool_state                  = "Running"
    min_size                    = 1
  }
```

The only way around this is to use the [`optional()`](https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes) variable feature which is still experimental.