### PR TITLE
Fix instance profile not present bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,8 +80,11 @@ resource "aws_launch_template" "default" {
 
   user_data = var.user_data_base64
 
-  iam_instance_profile {
-    name = var.iam_instance_profile_name
+  dynamic "iam_instance_profile" {
+    for_each = var.iam_instance_profile_name != "" ? [var.iam_instance_profile_name] : []
+    content {
+      name = iam_instance_profile.value
+    }
   }
 
   monitoring {


### PR DESCRIPTION
## what
- This block should not be defined if no instance profile name is present.

## why
- If `ec2_instance_profile` variable is not present terraform will want to continually apply the following block on the launch template every time terraform apply occurs. Additionally terraform wants to auto-increment the `latest_version`.
```
iam_instance_profile {}
```

## references
closes #71

