### PR TITLE
Fix: Remove Unused Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,6 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,8 +5,6 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,13 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
   }
 }


### PR DESCRIPTION
## what
* Remove unused providers: `hashicorp/template` and `hashicorp/null`.

## why

```bash
2 issue(s) found:

Warning: provider 'template' is declared in required_providers but not used by the module (terraform_unused_required_providers)

  on versions.tf line 9:
   9:     template = {
  10:       source  = "hashicorp/template"
  11:       version = ">= 2.0"
  12:     }

Reference: https://github.com/terraform-linters/tflint/blob/v0.27.0/docs/rules/terraform_unused_required_providers.md

Warning: provider 'null' is declared in required_providers but not used by the module (terraform_unused_required_providers)

  on versions.tf line 13:
  13:     null = {
  14:       source  = "hashicorp/null"
  15:       version = ">= 2.0"
  16:     }

Reference: https://github.com/terraform-linters/tflint/blob/v0.27.0/docs/rules/terraform_unused_required_providers.md

```

* The deprecated `hashicorp/template` is not available for all architectures.
* The deprecated `hashicorp/template` provider is unused, alongside `hashicorp/null` (not deprecated), which produces a `tflint` error when checking for unused providers (see above).

## references
* https://github.com/hashicorp/terraform-provider-template/issues/85
* Closes #80 

