### PR TITLE
enable optional ecs cluster creation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -492,3 +492,9 @@ variable "warm_pool" {
   description = "If this block is configured, add a Warm Pool to the specified Auto Scaling group. See [warm_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#warm_pool)."
   default     = null
 }
+
+variable "create_ecs_cluster" {
+  type        = bool
+  default     = false
+  description = "Create an ECS cluster to associate with the ASG"
+}


### PR DESCRIPTION
## what
* Enable optional creation of an ECS cluster with this module
* See #83

## why
* No CloudPosse module currently exists to create this resource
* Closes #83

