### PR TITLE
Add optional network_interface_id variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ resource "aws_launch_template" "default" {
   disable_api_termination = var.disable_api_termination
   ebs_optimized           = var.ebs_optimized
   update_default_version  = var.update_default_version
+  network_interface_id    = var.network_interface_id
 
   dynamic "elastic_gpu_specifications" {
     for_each = var.elastic_gpu_specifications != null ? [var.elastic_gpu_specifications] : []

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "security_group_ids" {
   default     = []
 }
 
+variable "network_interface_id" {
+  description = "The ID of the network interface to attach"
+  type        = string
+  default     = null
+}
+
 variable "launch_template_version" {
   type        = string
   description = "Launch template version. Can be version number, `$Latest` or `$Default`"


### PR DESCRIPTION
## what
* Add optional `network_interface_id` variable to launch_template

## why
* Allow the attaching of existing network interfaces

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#network_interface_id

