### PR TITLE
Remove deprecated output tags - alter to tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+---
+name: Bug report
+description: Create a report to help us improve
+labels: ["bug"]
+assignees: [""]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Found a bug?
+        
+        Please checkout our [Slack Community](https://slack.cloudposse.com)
+        or visit our [Slack Archive](https://archive.sweetops.com/).
+
+        [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+
+  - type: textarea
+    id: concise-description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+      placeholder: What is the bug about?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: How do we reproduce it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots or logs to help explain.
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Anything that will help us triage the bug.
+      placeholder: |
+        - OS: [e.g. Linux, OSX, WSL, etc]
+        - Version [e.g. 10.15]
+        - Module version
+        - Terraform version
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: |
+        Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+---
+name: Feature Request
+description: Suggest an idea for this project
+labels: ["feature request"]
+assignees: [""]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question?
+        
+        Please checkout our [Slack Community](https://slack.cloudposse.com)
+        or visit our [Slack Archive](https://archive.sweetops.com/).
+
+        [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+
+  - type: textarea
+    id: concise-description
+    attributes:
+      label: Describe the Feature
+      description: A clear and concise description of what the feature is.
+      placeholder: What is the feature about?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: |
+        Is your feature request related to a problem/challenge you are trying
+        to solve?
+        
+        Please provide some additional context of why this feature or
+        capability will be valuable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: ideal-solution
+    attributes:
+      label: Describe Ideal Solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives Considered
+      description: Explain alternative solutions or features considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: |
+        Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,21 @@
 ## what
-* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
-* Use bullet points to be concise and to the point.
+
+<!--
+- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+- Use bullet points to be concise and to the point.
+-->
 
 ## why
-* Provide the justifications for the changes (e.g. business case). 
-* Describe why these changes were made (e.g. why do these commits fix the problem?)
-* Use bullet points to be concise and to the point.
+
+<!--
+- Provide the justifications for the changes (e.g. business case). 
+- Describe why these changes were made (e.g. why do these commits fix the problem?)
+- Use bullet points to be concise and to the point.
+-->
 
 ## references
-* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
-* Use `closes #123`, if this PR closes a GitHub issue `#123`
 
+<!--
+- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
+- Use `closes #123`, if this PR closes a GitHub issue `#123`
+-->

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request::true"
+            echo "create_pull_request=true" >> "$GITHUB_OUTPUT"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
@@ -37,7 +37,7 @@ jobs:
       if: steps.update.outputs.create_pull_request == 'true'
       uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -19,7 +19,7 @@ jobs:
       if: github.event.pull_request.state == 'open'
       name: Privileged Checkout
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         # Check out the PR commit, not the merge commit
         # Use `ref` instead of `sha` to enable pushing back to `ref`
@@ -30,7 +30,7 @@ jobs:
       if: github.event.pull_request.state == 'open'
       shell: bash
       env:
-        GITHUB_TOKEN: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+        GITHUB_TOKEN: "${{ secrets.REPO_ACCESS_TOKEN }}"
       run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
 
     # Commit changes (if any) to the PR branch
@@ -54,10 +54,10 @@ jobs:
           [[ $SENDER ==  "cloudpossebot" ]] || git push
           # Set status to fail, because the push should trigger another status check,
           # and we use success to indicate the checks are finished.
-          printf "::set-output name=%s::%s\n" "changed" "true"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
           exit 1
         else
-          printf "::set-output name=%s::%s\n" "changed" "false"
+          echo "changed=false" >> "$GITHUB_OUTPUT"
           echo "No changes detected"
         fi
 
@@ -75,7 +75,7 @@ jobs:
         contains(' 37929162 29139614 11232728 ', format(' {0} ', github.event.pull_request.user.id))
         && steps.commit.outputs.changed == 'false' && github.event.pull_request.state == 'open'
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         repository: cloudposse/actions
         event-type: test-command
         client-payload: |-

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -29,7 +29,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        echo "defaultBranch=${default_branch}" >> "$GITHUB_OUTPUT"
         printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme
@@ -52,7 +52,7 @@ jobs:
       # If a PR of the auto-update/readme branch is open, this action will just update it, not create a new PR.
       uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         commit-message: Update README.md and docs
         title: Update README.md and docs
         body: |-

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
         with:
-          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          github_token: ${{ secrets.REPO_ACCESS_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         with:
@@ -23,4 +23,4 @@ jobs:
           prerelease: false
           config-name: auto-release.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -11,7 +11,7 @@ jobs:
       - name: "Handle common commands"
         uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: rebuild-readme, terraform-fmt
@@ -26,7 +26,7 @@ jobs:
       - name: "Run tests"
         uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: test

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -21,7 +21,7 @@ jobs:
         checks: "syntax,owners,duppatterns"
         owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
-        github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+        github_access_token: "${{ secrets.REPO_ACCESS_TOKEN }}"
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Available targets:
 | <a name="output_autoscaling_group_max_size"></a> [autoscaling\_group\_max\_size](#output\_autoscaling\_group\_max\_size) | The maximum size of the autoscale group |
 | <a name="output_autoscaling_group_min_size"></a> [autoscaling\_group\_min\_size](#output\_autoscaling\_group\_min\_size) | The minimum size of the autoscale group |
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | The AutoScaling Group name |
-| <a name="output_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#output\_autoscaling\_group\_tags) | A list of tag settings associated with the AutoScaling Group |
+| <a name="output_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#output\_autoscaling\_group\_tags) | A set of maps containing tags associated with the AutoScaling Group |
 | <a name="output_autoscaling_policy_scale_down_arn"></a> [autoscaling\_policy\_scale\_down\_arn](#output\_autoscaling\_policy\_scale\_down\_arn) | ARN of the AutoScaling policy scale down |
 | <a name="output_autoscaling_policy_scale_up_arn"></a> [autoscaling\_policy\_scale\_up\_arn](#output\_autoscaling\_policy\_scale\_up\_arn) | ARN of the AutoScaling policy scale up |
 | <a name="output_launch_template_arn"></a> [launch\_template\_arn](#output\_launch\_template\_arn) | The ARN of the launch template |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -133,7 +133,7 @@
 | <a name="output_autoscaling_group_max_size"></a> [autoscaling\_group\_max\_size](#output\_autoscaling\_group\_max\_size) | The maximum size of the autoscale group |
 | <a name="output_autoscaling_group_min_size"></a> [autoscaling\_group\_min\_size](#output\_autoscaling\_group\_min\_size) | The minimum size of the autoscale group |
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | The AutoScaling Group name |
-| <a name="output_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#output\_autoscaling\_group\_tags) | A list of tag settings associated with the AutoScaling Group |
+| <a name="output_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#output\_autoscaling\_group\_tags) | A set of maps containing tags associated with the AutoScaling Group |
 | <a name="output_autoscaling_policy_scale_down_arn"></a> [autoscaling\_policy\_scale\_down\_arn](#output\_autoscaling\_policy\_scale\_down\_arn) | ARN of the AutoScaling policy scale down |
 | <a name="output_autoscaling_policy_scale_up_arn"></a> [autoscaling\_policy\_scale\_up\_arn](#output\_autoscaling\_policy\_scale\_up\_arn) | ARN of the AutoScaling policy scale up |
 | <a name="output_launch_template_arn"></a> [launch\_template\_arn](#output\_launch\_template\_arn) | The ARN of the launch template |

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,11 +18,6 @@ output "autoscaling_group_name" {
   value       = join("", aws_autoscaling_group.default.*.name)
 }
 
-output "autoscaling_group_tags" {
-  description = "A list of tag settings associated with the AutoScaling Group"
-  value       = module.this.enabled ? aws_autoscaling_group.default[0].tags : []
-}
-
 output "autoscaling_group_arn" {
   description = "ARN of the AutoScaling Group"
   value       = join("", aws_autoscaling_group.default.*.arn)

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "autoscaling_group_name" {
 
 output "autoscaling_group_tags" {
   description = "A set of maps containing tags associated with the AutoScaling Group"
-  value       = module.this.enabled ? aws_autoscaling_group.default[0].tag : []
+  value       = module.this.enabled ? aws_autoscaling_group.default[0].tags : []
 }
 
 output "autoscaling_group_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "autoscaling_group_name" {
   value       = join("", aws_autoscaling_group.default.*.name)
 }
 
+output "autoscaling_group_tags" {
+  description = "A set of maps containing tags associated with the AutoScaling Group"
+  value       = module.this.enabled ? aws_autoscaling_group.default[0].tag : []
+}
+
 output "autoscaling_group_arn" {
   description = "ARN of the AutoScaling Group"
   value       = join("", aws_autoscaling_group.default.*.arn)

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "autoscaling_group_name" {
 
 output "autoscaling_group_tags" {
   description = "A set of maps containing tags associated with the AutoScaling Group"
-  value       = module.this.enabled ? aws_autoscaling_group.default[0].tags : []
+  value       = module.this.enabled ? aws_autoscaling_group.default[0].tag : []
 }
 
 output "autoscaling_group_arn" {


### PR DESCRIPTION
The resource ```aws_autoscaling_group``` can have either a ```tags``` or ```tag``` value set.

```tags``` is deprecated.

```output.tf``` is currently outputing ```tags``` and it produces this error:

![image](https://user-images.githubusercontent.com/61512176/231242329-c020fedf-afbc-41e6-ab4c-46fb84ee5594.png)

This PR alters the ```output.tf``` file to use ```tag``` rather than ```tags```.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#tags
