### PR TITLE
feat: Add support for aws provider 5.0

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "autoscaling_group_name" {
 
 output "autoscaling_group_tags" {
   description = "A list of tag settings associated with the AutoScaling Group"
-  value       = module.this.enabled ? aws_autoscaling_group.default[0].tags : []
+  value       = module.this.enabled ? aws_autoscaling_group.default[0].tag : []
 }
 
 output "autoscaling_group_arn" {


### PR DESCRIPTION
## why

That field was deprecated in 4.0 and was removed in 5.0

Note:

```
make init
make github/init
make readme
```

Already ran and committed