### PR TITLE
Support AWS Provider V5

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,6 @@ Available targets:
 | <a name="output_autoscaling_group_max_size"></a> [autoscaling\_group\_max\_size](#output\_autoscaling\_group\_max\_size) | The maximum size of the autoscale group |
 | <a name="output_autoscaling_group_min_size"></a> [autoscaling\_group\_min\_size](#output\_autoscaling\_group\_min\_size) | The minimum size of the autoscale group |
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | The AutoScaling Group name |
-| <a name="output_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#output\_autoscaling\_group\_tags) | A list of tag settings associated with the AutoScaling Group |
 | <a name="output_autoscaling_policy_scale_down_arn"></a> [autoscaling\_policy\_scale\_down\_arn](#output\_autoscaling\_policy\_scale\_down\_arn) | ARN of the AutoScaling policy scale down |
 | <a name="output_autoscaling_policy_scale_up_arn"></a> [autoscaling\_policy\_scale\_up\_arn](#output\_autoscaling\_policy\_scale\_up\_arn) | ARN of the AutoScaling policy scale up |
 | <a name="output_launch_template_arn"></a> [launch\_template\_arn](#output\_launch\_template\_arn) | The ARN of the launch template |

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
 
 ## Providers

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -10,7 +10,7 @@ resource "aws_autoscaling_policy" "scale_up" {
   adjustment_type        = var.scale_up_adjustment_type
   policy_type            = var.scale_up_policy_type
   cooldown               = var.scale_up_cooldown_seconds
-  autoscaling_group_name = join("", aws_autoscaling_group.default.*.name)
+  autoscaling_group_name = one(aws_autoscaling_group.default[*].name)
 }
 
 resource "aws_autoscaling_policy" "scale_down" {
@@ -20,7 +20,7 @@ resource "aws_autoscaling_policy" "scale_down" {
   adjustment_type        = var.scale_down_adjustment_type
   policy_type            = var.scale_down_policy_type
   cooldown               = var.scale_down_cooldown_seconds
-  autoscaling_group_name = join("", aws_autoscaling_group.default.*.name)
+  autoscaling_group_name = one(aws_autoscaling_group.default[*].name)
 }
 
 locals {
@@ -36,9 +36,9 @@ locals {
       extended_statistic        = null
       threshold                 = var.cpu_utilization_high_threshold_percent
       dimensions_name           = "AutoScalingGroupName"
-      dimensions_target         = join("", aws_autoscaling_group.default.*.name)
+      dimensions_target         = one(aws_autoscaling_group.default[*].name)
       alarm_description         = "Scale up if CPU utilization is above ${var.cpu_utilization_high_threshold_percent} for ${var.cpu_utilization_high_period_seconds} * ${var.cpu_utilization_high_evaluation_periods} seconds"
-      alarm_actions             = [join("", aws_autoscaling_policy.scale_up.*.arn)]
+      alarm_actions             = [one(aws_autoscaling_policy.scale_up[*].arn)]
       treat_missing_data        = "missing"
       ok_actions                = []
       insufficient_data_actions = []
@@ -54,9 +54,9 @@ locals {
       extended_statistic        = null
       threshold                 = var.cpu_utilization_low_threshold_percent
       dimensions_name           = "AutoScalingGroupName"
-      dimensions_target         = join("", aws_autoscaling_group.default.*.name)
+      dimensions_target         = one(aws_autoscaling_group.default[*].name)
       alarm_description         = "Scale down if the CPU utilization is below ${var.cpu_utilization_low_threshold_percent} for ${var.cpu_utilization_low_period_seconds} * ${var.cpu_utilization_high_evaluation_periods} seconds"
-      alarm_actions             = [join("", aws_autoscaling_policy.scale_down.*.arn)]
+      alarm_actions             = [one(aws_autoscaling_policy.scale_down[*].arn)]
       treat_missing_data        = "missing"
       ok_actions                = []
       insufficient_data_actions = []

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -133,7 +133,6 @@
 | <a name="output_autoscaling_group_max_size"></a> [autoscaling\_group\_max\_size](#output\_autoscaling\_group\_max\_size) | The maximum size of the autoscale group |
 | <a name="output_autoscaling_group_min_size"></a> [autoscaling\_group\_min\_size](#output\_autoscaling\_group\_min\_size) | The minimum size of the autoscale group |
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | The AutoScaling Group name |
-| <a name="output_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#output\_autoscaling\_group\_tags) | A list of tag settings associated with the AutoScaling Group |
 | <a name="output_autoscaling_policy_scale_down_arn"></a> [autoscaling\_policy\_scale\_down\_arn](#output\_autoscaling\_policy\_scale\_down\_arn) | ARN of the AutoScaling policy scale down |
 | <a name="output_autoscaling_policy_scale_up_arn"></a> [autoscaling\_policy\_scale\_up\_arn](#output\_autoscaling\_policy\_scale\_up\_arn) | ARN of the AutoScaling policy scale up |
 | <a name="output_launch_template_arn"></a> [launch\_template\_arn](#output\_launch\_template\_arn) | The ARN of the launch template |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
 
 ## Providers

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 module "vpc" {
   source     = "cloudposse/vpc/aws"
   version    = "2.1.0"
-  cidr_block = "172.16.0.0/16"
+  ipv4_primary_cidr_block = "172.16.0.0/16"
 
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "vpc" {
   source     = "cloudposse/vpc/aws"
-  version    = "0.18.1"
+  version    = "2.1.0"
   cidr_block = "172.16.0.0/16"
 
   context = module.this.context

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,7 +17,7 @@ module "subnets" {
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
+  ipv4_cidr_block      = module.vpc.vpc_cidr_block
   nat_gateway_enabled  = false
   nat_instance_enabled = false
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -16,8 +16,8 @@ module "subnets" {
   version              = "2.3.0"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  ipv4_cidr_block      = module.vpc.vpc_cidr_block
+  igw_id               = [module.vpc.igw_id]
+  ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = false
   nat_instance_enabled = false
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,6 +5,7 @@ provider "aws" {
 module "vpc" {
   source     = "cloudposse/vpc/aws"
   version    = "2.1.0"
+  
   ipv4_primary_cidr_block = "172.16.0.0/16"
 
   context = module.this.context

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -12,7 +12,7 @@ module "vpc" {
 
 module "subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.38.0"
+  version              = "2.3.0"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,9 +3,9 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "cloudposse/vpc/aws"
-  version    = "2.1.0"
-  
+  source  = "cloudposse/vpc/aws"
+  version = "2.1.0"
+
   ipv4_primary_cidr_block = "172.16.0.0/16"
 
   context = module.this.context

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -127,8 +127,8 @@ resource "aws_launch_template" "default" {
 
 locals {
   launch_template_block = {
-    id      = join("", aws_launch_template.default.*.id)
-    version = var.launch_template_version != "" ? var.launch_template_version : join("", aws_launch_template.default.*.latest_version)
+    id      = one(aws_launch_template.default[*].id)
+    version = var.launch_template_version != "" ? var.launch_template_version : one(aws_launch_template.default[*].latest_version)
   }
   launch_template = (
     var.mixed_instances_policy == null ? local.launch_template_block

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,69 +1,64 @@
 output "launch_template_id" {
   description = "The ID of the launch template"
-  value       = join("", aws_launch_template.default.*.id)
+  value       = one(aws_launch_template.default[*].id)
 }
 
 output "launch_template_arn" {
   description = "The ARN of the launch template"
-  value       = join("", aws_launch_template.default.*.arn)
+  value       = one(aws_launch_template.default[*].arn)
 }
 
 output "autoscaling_group_id" {
   description = "The AutoScaling Group id"
-  value       = join("", aws_autoscaling_group.default.*.id)
+  value       = one(aws_autoscaling_group.default[*].id)
 }
 
 output "autoscaling_group_name" {
   description = "The AutoScaling Group name"
-  value       = join("", aws_autoscaling_group.default.*.name)
-}
-
-output "autoscaling_group_tags" {
-  description = "A list of tag settings associated with the AutoScaling Group"
-  value       = module.this.enabled ? aws_autoscaling_group.default[0].tags : []
+  value       = one(aws_autoscaling_group.default[*].name)
 }
 
 output "autoscaling_group_arn" {
   description = "ARN of the AutoScaling Group"
-  value       = join("", aws_autoscaling_group.default.*.arn)
+  value       = one(aws_autoscaling_group.default[*].arn)
 }
 
 output "autoscaling_group_min_size" {
   description = "The minimum size of the autoscale group"
-  value       = join("", aws_autoscaling_group.default.*.min_size)
+  value       = one(aws_autoscaling_group.default[*].min_size)
 }
 
 output "autoscaling_group_max_size" {
   description = "The maximum size of the autoscale group"
-  value       = join("", aws_autoscaling_group.default.*.max_size)
+  value       = one(aws_autoscaling_group.default[*].max_size)
 }
 
 output "autoscaling_group_desired_capacity" {
   description = "The number of Amazon EC2 instances that should be running in the group"
-  value       = join("", aws_autoscaling_group.default.*.desired_capacity)
+  value       = one(aws_autoscaling_group.default[*].desired_capacity)
 }
 
 output "autoscaling_group_default_cooldown" {
   description = "Time between a scaling activity and the succeeding scaling activity"
-  value       = join("", aws_autoscaling_group.default.*.default_cooldown)
+  value       = one(aws_autoscaling_group.default[*].default_cooldown)
 }
 
 output "autoscaling_group_health_check_grace_period" {
   description = "Time after instance comes into service before checking health"
-  value       = join("", aws_autoscaling_group.default.*.health_check_grace_period)
+  value       = one(aws_autoscaling_group.default[*].health_check_grace_period)
 }
 
 output "autoscaling_group_health_check_type" {
   description = "`EC2` or `ELB`. Controls how health checking is done"
-  value       = join("", aws_autoscaling_group.default.*.health_check_type)
+  value       = one(aws_autoscaling_group.default[*].health_check_type)
 }
 
 output "autoscaling_policy_scale_down_arn" {
   description = "ARN of the AutoScaling policy scale down"
-  value       = join("", aws_autoscaling_policy.scale_down.*.arn)
+  value       = one(aws_autoscaling_policy.scale_down[*].arn)
 }
 
 output "autoscaling_policy_scale_up_arn" {
   description = "ARN of the AutoScaling policy scale up"
-  value       = join("", aws_autoscaling_policy.scale_up.*.arn)
+  value       = one(aws_autoscaling_policy.scale_up[*].arn)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what

- Support AWS Provider V5
- Linter fixes
- Bump tf version

## why

resource/aws_autoscaling_group: Remove deprecated tags attribute (https://github.com/hashicorp/terraform-provider-aws/issues/30842)

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0