### PR TITLE
Restore tags output

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Available targets:
 | <a name="output_autoscaling_group_max_size"></a> [autoscaling\_group\_max\_size](#output\_autoscaling\_group\_max\_size) | The maximum size of the autoscale group |
 | <a name="output_autoscaling_group_min_size"></a> [autoscaling\_group\_min\_size](#output\_autoscaling\_group\_min\_size) | The minimum size of the autoscale group |
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | The AutoScaling Group name |
+| <a name="output_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#output\_autoscaling\_group\_tags) | A list of tag settings associated with the AutoScaling Group |
 | <a name="output_autoscaling_policy_scale_down_arn"></a> [autoscaling\_policy\_scale\_down\_arn](#output\_autoscaling\_policy\_scale\_down\_arn) | ARN of the AutoScaling policy scale down |
 | <a name="output_autoscaling_policy_scale_up_arn"></a> [autoscaling\_policy\_scale\_up\_arn](#output\_autoscaling\_policy\_scale\_up\_arn) | ARN of the AutoScaling policy scale up |
 | <a name="output_launch_template_arn"></a> [launch\_template\_arn](#output\_launch\_template\_arn) | The ARN of the launch template |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -133,6 +133,7 @@
 | <a name="output_autoscaling_group_max_size"></a> [autoscaling\_group\_max\_size](#output\_autoscaling\_group\_max\_size) | The maximum size of the autoscale group |
 | <a name="output_autoscaling_group_min_size"></a> [autoscaling\_group\_min\_size](#output\_autoscaling\_group\_min\_size) | The minimum size of the autoscale group |
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | The AutoScaling Group name |
+| <a name="output_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#output\_autoscaling\_group\_tags) | A list of tag settings associated with the AutoScaling Group |
 | <a name="output_autoscaling_policy_scale_down_arn"></a> [autoscaling\_policy\_scale\_down\_arn](#output\_autoscaling\_policy\_scale\_down\_arn) | ARN of the AutoScaling policy scale down |
 | <a name="output_autoscaling_policy_scale_up_arn"></a> [autoscaling\_policy\_scale\_up\_arn](#output\_autoscaling\_policy\_scale\_up\_arn) | ARN of the AutoScaling policy scale up |
 | <a name="output_launch_template_arn"></a> [launch\_template\_arn](#output\_launch\_template\_arn) | The ARN of the launch template |

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "autoscaling_group_name" {
   value       = one(aws_autoscaling_group.default[*].name)
 }
 
+output "autoscaling_group_tags" {
+  description = "A list of tag settings associated with the AutoScaling Group"
+  value       = module.this.enabled ? aws_autoscaling_group.default[0].tag : []
+}
+
 output "autoscaling_group_arn" {
   description = "ARN of the AutoScaling Group"
   value       = one(aws_autoscaling_group.default[*].arn)


### PR DESCRIPTION
## what

- Restore `autoscaling_group_tags` output removed in #113 

## why

- Maintain backwards compatibility

