### PR TITLE
Support AWS Provider V5

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 module "vpc" {
   source                  = "cloudposse/vpc/aws"
   version                 = "2.1.0"
-  ipv4_primary_cidr_block = var.vpc_cidr_block
+  ipv4_primary_cidr_block = "172.16.0.0/16"
   context                 = module.this.context
 }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,12 +3,10 @@ provider "aws" {
 }
 
 module "vpc" {
-  source  = "cloudposse/vpc/aws"
-  version = "2.1.0"
-
-  ipv4_primary_cidr_block = "172.16.0.0/16"
-
-  context = module.this.context
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.1.0"
+  ipv4_primary_cidr_block = var.vpc_cidr_block
+  context                 = module.this.context
 }
 
 module "subnets" {
@@ -20,8 +18,7 @@ module "subnets" {
   ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = false
   nat_instance_enabled = false
-
-  context = module.this.context
+  context              = module.this.context
 }
 
 module "autoscale_group" {


### PR DESCRIPTION
## what

Support AWS Provider V5
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
