### PR TITLE
fix: Tagging

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -87,5 +87,5 @@ resource "aws_cloudwatch_metric_alarm" "all_alarms" {
 
   alarm_description = each.value.alarm_description
   alarm_actions     = each.value.alarm_actions
-  tags              = var.tags
+  tags              = module.this.tags
 }


### PR DESCRIPTION
## why

`var.tags` does not provide any tags if you rely on `context`:

```tf
module {
  ...
  context = module.this.context
}
```
