### PR TITLE
add max_healthy_percentage - option used during instance refresh

### DIFF
--- a/examples/complete/fixtures-mixed-instance-policy.us-east-2.tfvars
+++ b/examples/complete/fixtures-mixed-instance-policy.us-east-2.tfvars
@@ -8,7 +8,7 @@ stage = "test"
 
 name = "ec2-autoscale-group"
 
-image_id = "ami-0182f373e66f89c85"
+image_id = "ami-00c03f7f7f2ec15c3"
 
 instance_type = "t2.small"
 
@@ -34,4 +34,3 @@ mixed_instances_policy = {
     weighted_capacity = null
   }]
 }
-

--- a/examples/complete/fixtures-mixed-instance-policy.us-east-2.tfvars
+++ b/examples/complete/fixtures-mixed-instance-policy.us-east-2.tfvars
@@ -8,7 +8,7 @@ stage = "test"
 
 name = "ec2-autoscale-group"
 
-image_id = "ami-013b3de8a8fa9b39f"
+image_id = "ami-0182f373e66f89c85"
 
 instance_type = "t2.small"
 

--- a/examples/complete/fixtures-mixed-instance-policy.us-east-2.tfvars
+++ b/examples/complete/fixtures-mixed-instance-policy.us-east-2.tfvars
@@ -8,7 +8,7 @@ stage = "test"
 
 name = "ec2-autoscale-group"
 
-image_id = "ami-00c03f7f7f2ec15c3"
+image_id = "ami-013b3de8a8fa9b39f"
 
 instance_type = "t2.small"
 
@@ -34,3 +34,4 @@ mixed_instances_policy = {
     weighted_capacity = null
   }]
 }
+

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -8,7 +8,7 @@ stage = "test"
 
 name = "ec2-autoscale-group"
 
-image_id = "ami-0182f373e66f89c85"
+image_id = "ami-00c03f7f7f2ec15c3"
 
 instance_type = "t2.small"
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -8,7 +8,7 @@ stage = "test"
 
 name = "ec2-autoscale-group"
 
-image_id = "ami-013b3de8a8fa9b39f"
+image_id = "ami-0182f373e66f89c85"
 
 instance_type = "t2.small"
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -8,7 +8,7 @@ stage = "test"
 
 name = "ec2-autoscale-group"
 
-image_id = "ami-00c03f7f7f2ec15c3"
+image_id = "ami-013b3de8a8fa9b39f"
 
 instance_type = "t2.small"
 

--- a/main.tf
+++ b/main.tf
@@ -191,6 +191,7 @@ resource "aws_autoscaling_group" "default" {
         content {
           instance_warmup              = lookup(preferences.value, "instance_warmup", null)
           min_healthy_percentage       = lookup(preferences.value, "min_healthy_percentage", null)
+          max_healthy_percentage       = lookup(preferences.value, "max_healthy_percentage", null)
           skip_matching                = lookup(preferences.value, "skip_matching", null)
           auto_rollback                = lookup(preferences.value, "auto_rollback", null)
           scale_in_protected_instances = lookup(preferences.value, "scale_in_protected_instances", null)

--- a/variables.tf
+++ b/variables.tf
@@ -121,6 +121,7 @@ variable "instance_refresh" {
     preferences = optional(object({
       instance_warmup              = optional(number, null)
       min_healthy_percentage       = optional(number, null)
+      max_healthy_percentage       = optional(number, null)
       skip_matching                = optional(bool, null)
       auto_rollback                = optional(bool, null)
       scale_in_protected_instances = optional(string, null)


### PR DESCRIPTION
## what

This is adding the ```max_healthy_percentage``` option.

This allows the instance refresh to set this value.

```min_healthy_percentage``` is already set as an option.

## why

The option is currently missing from the terraform module.

## references

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#max_healthy_percentage
