### PR TITLE
fix: remove deprecated `elastic_gpu_specifications`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,13 +42,6 @@ resource "aws_launch_template" "default" {
   ebs_optimized           = var.ebs_optimized
   update_default_version  = var.update_default_version
 
-  dynamic "elastic_gpu_specifications" {
-    for_each = var.elastic_gpu_specifications != null ? [var.elastic_gpu_specifications] : []
-    content {
-      type = lookup(elastic_gpu_specifications.value, "type", null)
-    }
-  }
-
   image_id                             = var.image_id
   instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
 

--- a/variables.tf
+++ b/variables.tf
@@ -177,16 +177,6 @@ variable "credit_specification" {
   default = null
 }
 
-variable "elastic_gpu_specifications" {
-  description = "Specifications of Elastic GPU to attach to the instances"
-
-  type = object({
-    type = string
-  })
-
-  default = null
-}
-
 variable "disable_api_termination" {
   type        = bool
   description = "If `true`, enables EC2 Instance Termination Protection"


### PR DESCRIPTION
## what

_Amazon Elastic Graphics died on 8 Jan 2024, and the AWS provider yanked the knob in `v6.0.0`. Use GPU-class instance types (G4*/G5, etc.) or other modern accelerators instead._

## What

- Resolves the following error in pipeline:

```console
│ Error: Unsupported block type
│ 
│   on .terraform/infra/modules/autoscale_group/main.tf line 39, in resource "aws_launch_template" "default":
│   39:   dynamic "elastic_gpu_specifications" {
│ 
│ Blocks of type "elastic_gpu_specifications" are not expected here.
```

---

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

- [X] Validated with `atmos validate stacks`
- [X] Performed successful `atmos terraform plan` on component using this module

## References

- [EOL Announcement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade#resource-aws_launch_template)


