### PR TITLE
Lock version to v5

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.16"
+      version = "~> 5.16"
     }
   }
 }


### PR DESCRIPTION
provider v6 breaks current implementation of assigning elastic gpu

## what

- Locked provider to  v5 major to prevent errors
## why

v5, this worked... v6 throws this:
│ Error: Unsupported block type
│ 
│   on .terraform/modules/autoscale_group/main.tf line 45, in resource "aws_launch_template" "default":
│   45:   dynamic "elastic_gpu_specifications" {
│ 
│ Blocks of type "elastic_gpu_specifications" are not expected here.
╵
Operation failed: failed running terraform plan (exit 1)
ERRO exit status 1

## references

